### PR TITLE
Check whether the scene list has changed at all in scene change callback

### DIFF
--- a/obs-transition-matrix.cpp
+++ b/obs-transition-matrix.cpp
@@ -298,6 +298,9 @@ static void handle_scene_list_changed()
 
 		return;
 	} else if (newSceneNames.size() == sceneNames.size()) {
+		if (newSceneNames == sceneNames)
+			return;
+
 		string name;
 		string removed;
 		for (const string &s : newSceneNames)


### PR DESCRIPTION
Otherwise certain operations (rename a scene without actually changing its name, removing a scene using the context menu) could cause a crash when the callback is triggered without any actual change to the scene list.

Note that we can use "==" here since `newSceneNames` and `sceneNames` are both `std::set`s.